### PR TITLE
feat: allow ipBlocks to be specified in helmchart network policy

### DIFF
--- a/helm/templates/networkpolicy.yaml
+++ b/helm/templates/networkpolicy.yaml
@@ -46,7 +46,15 @@ spec:
       port: {{ .Values.networkPolicy.egress.dnsPort | default 53 }}
 
   # Allow Egress to other required services
-  - to: []
+  - to:
+    {{- if .Values.networkPolicy.egress.allowedIpBlocks }}
+    {{- range .Values.networkPolicy.egress.allowedIpBlocks }}
+    - ipBlock:
+        cidr: {{ .cidr }}
+    {{- end }}
+    {{- else }}
+    []
+    {{- end }}
     ports:
     {{- range .Values.networkPolicy.egress.allowedPorts }}
     - protocol: {{ .protocol | default "TCP" }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -106,3 +106,4 @@ networkPolicy:
         protocol: TCP
       - port: 9440
         protocol: TCP
+    allowedIpBlocks: # Define IP blocks for egress

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -107,3 +107,4 @@ networkPolicy:
       - port: 9440
         protocol: TCP
     allowedIpBlocks: # Define IP blocks for egress
+    

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -107,4 +107,3 @@ networkPolicy:
       - port: 9440
         protocol: TCP
     allowedIpBlocks: # Define IP blocks for egress
-    


### PR DESCRIPTION
Adding option to define ipBlocks in the helmchart networkpolicy egress rules:
- Added a new value `allowedIpBlocks` as a list of objects to define IP blocks
